### PR TITLE
fix: use string type for params with array type

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@vkontakte/api-schema": "https://github.com/VKCOM/vk-api-schema.git#v5.126.11",
-    "@vkontakte/api-schema-typescript-generator": "0.4.0",
+    "@vkontakte/api-schema-typescript-generator": "0.5.0",
     "typescript": "^3.9.6"
   },
   "scripts": {

--- a/src/methods/account.ts
+++ b/src/methods/account.ts
@@ -136,7 +136,7 @@ export interface AccountGetCountersParams {
   /**
    * Counters to be returned.
    */
-  filter?: string[];
+  filter?: string;
 }
 
 // account.getCounters_response
@@ -152,7 +152,7 @@ export interface AccountGetInfoParams {
   /**
    * Fields to return. Possible values: *'country' — user country,, *'https_required' — is "HTTPS only" option enabled,, *'own_posts_default' — is "Show my posts only" option is enabled,, *'no_wall_replies' — are wall replies disabled or not,, *'intro' — is intro passed by user or not,, *'lang' — user language. By default: all.
    */
-  fields?: string[];
+  fields?: string;
 }
 
 // account.getInfo_response
@@ -385,7 +385,7 @@ export interface AccountSetPushSettingsParams {
   /**
    * New value for the key in a [vk.com/dev/push_settings|special format].
    */
-  value?: string[];
+  value?: string;
 }
 
 // account.setPushSettings_response

--- a/src/methods/ads.ts
+++ b/src/methods/ads.ts
@@ -25,8 +25,6 @@ import { AdsTargSuggestionsRegions } from '../objects/ads/AdsTargSuggestionsRegi
 import { AdsTargSuggestionsSchools } from '../objects/ads/AdsTargSuggestionsSchools';
 import { AdsUpdateOfficeUsersResult } from '../objects/ads/AdsUpdateOfficeUsersResult';
 import { AdsUsers } from '../objects/ads/AdsUsers';
-import { AdsUserSpecification } from '../objects/ads/AdsUserSpecification';
-import { AdsUserSpecificationCutted } from '../objects/ads/AdsUserSpecificationCutted';
 
 /**
  * ads.addOfficeUsers
@@ -41,8 +39,10 @@ export interface AdsAddOfficeUsersParams {
   account_id: number;
   /**
    * Serialized JSON array of objects that describe added managers. Description of 'user_specification' objects see below.
+   *
+   * objects.json#/definitions/ads_user_specification_cutted
    */
-  data: AdsUserSpecificationCutted[];
+  data: string;
 }
 
 // ads.addOfficeUsers_response
@@ -433,7 +433,7 @@ export interface AdsGetCampaignsParams {
    * Filter of advertising campaigns to show. Serialized JSON array with campaign IDs. Only campaigns that exist in 'campaign_ids' and belong to the specified advertising account will be shown. If the parameter is null, all campaigns will be shown.
    */
   campaign_ids?: string;
-  fields?: string[];
+  fields?: string;
 }
 
 // ads.getCampaigns_response
@@ -667,7 +667,7 @@ export interface AdsGetStatisticsParams {
   /**
    * Additional fields to add to statistics
    */
-  stats_fields?: string[];
+  stats_fields?: string;
 }
 
 // ads.getStatistics_response
@@ -953,8 +953,10 @@ export interface AdsUpdateOfficeUsersParams {
   account_id: number;
   /**
    * Serialized JSON array of objects that describe added managers. Description of 'user_specification' objects see below.
+   *
+   * objects.json#/definitions/ads_user_specification
    */
-  data: AdsUserSpecification[];
+  data: string;
 }
 
 // ads.updateOfficeUsers_response

--- a/src/methods/appWidgets.ts
+++ b/src/methods/appWidgets.ts
@@ -93,7 +93,7 @@ export interface AppWidgetsGetImagesByIdParams {
   /**
    * List of images IDs
    */
-  images: string[];
+  images: string;
 }
 
 // appWidgets.getImagesById_response

--- a/src/methods/apps.ts
+++ b/src/methods/apps.ts
@@ -5,7 +5,6 @@
 import { AppsApp } from '../objects/apps/AppsApp';
 import { AppsLeaderboard } from '../objects/apps/AppsLeaderboard';
 import { AppsScope } from '../objects/apps/AppsScope';
-import { UsersFields } from '../objects/users/UsersFields';
 import { UsersUserFull } from '../objects/users/UsersUserFull';
 import { UsersUserMin } from '../objects/users/UsersUserMin';
 
@@ -34,7 +33,7 @@ export interface AppsGetParams {
   /**
    * List of application ID
    */
-  app_ids?: string[];
+  app_ids?: string;
   /**
    * platform. Possible values: *'ios' — iOS,, *'android' — Android,, *'winphone' — Windows Phone,, *'web' — приложения на vk.com. By default: 'web'.
    */
@@ -43,8 +42,10 @@ export interface AppsGetParams {
   return_friends?: 0 | 1;
   /**
    * Profile fields to return. Sample values: 'nickname', 'screen_name', 'sex', 'bdate' (birthdate), 'city', 'country', 'timezone', 'photo', 'photo_medium', 'photo_big', 'has_mobile', 'contacts', 'education', 'online', 'counters', 'relation', 'last_seen', 'activity', 'can_write_private_message', 'can_see_all_posts', 'can_post', 'universities', (only if return_friends - 1)
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * Case for declension of user name and surname: 'nom' — nominative (default),, 'gen' — genitive,, 'dat' — dative,, 'acc' — accusative,, 'ins' — instrumental,, 'abl' — prepositional. (only if 'return_friends' = '1')
    */
@@ -88,7 +89,10 @@ export interface AppsGetCatalogParams {
    */
   extended?: 0 | 1;
   return_friends?: 0 | 1;
-  fields?: UsersFields[];
+  /**
+   * objects.json#/definitions/users_fields
+   */
+  fields?: string;
   name_case?: string;
   /**
    * Search query string.
@@ -130,8 +134,10 @@ export interface AppsGetFriendsListParams {
   type?: 'invite' | 'request';
   /**
    * Additional profile fields, see [vk.com/dev/fields|description].
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
 }
 
 // apps.getFriendsList_response

--- a/src/methods/board.ts
+++ b/src/methods/board.ts
@@ -36,7 +36,7 @@ export interface BoardAddTopicParams {
   /**
    * List of media objects attached to the topic, in the following format: "<owner_id>_<media_id>,<owner_id>_<media_id>", '' — Type of media object: 'photo' — photo, 'video' — video, 'audio' — audio, 'doc' — document, '<owner_id>' — ID of the media owner. '<media_id>' — Media ID. Example: "photo100172_166443618,photo66748_265827614", , "NOTE: If you try to attach more than one reference, an error will be thrown.",
    */
-  attachments?: string[];
+  attachments?: string;
 }
 
 // board.addTopic_response
@@ -84,7 +84,7 @@ export interface BoardCreateCommentParams {
   /**
    * (Required if 'text' is not set.) List of media objects attached to the comment, in the following format: "<owner_id>_<media_id>,<owner_id>_<media_id>", '' — Type of media object: 'photo' — photo, 'video' — video, 'audio' — audio, 'doc' — document, '<owner_id>' — ID of the media owner. '<media_id>' — Media ID.
    */
-  attachments?: string[];
+  attachments?: string;
   /**
    * '1' — to post the comment as by the community, '0' — to post the comment as by the user (default)
    */
@@ -172,7 +172,7 @@ export interface BoardEditCommentParams {
   /**
    * (Required if 'message' is not set.) List of media objects attached to the comment, in the following format: "<owner_id>_<media_id>,<owner_id>_<media_id>", '' — Type of media object: 'photo' — photo, 'video' — video, 'audio' — audio, 'doc' — document, '<owner_id>' — ID of the media owner. '<media_id>' — Media ID. Example: "photo100172_166443618,photo66748_265827614"
    */
-  attachments?: string[];
+  attachments?: string;
 }
 
 // board.editComment_response
@@ -296,7 +296,7 @@ export interface BoardGetTopicsParams {
   /**
    * IDs of topics to be returned (100 maximum). By default, all topics are returned. If this parameter is set, the 'order', 'offset', and 'count' parameters are ignored.
    */
-  topic_ids?: number[];
+  topic_ids?: string;
   /**
    * Sort order: '1' — by date updated in reverse chronological order. '2' — by date created in reverse chronological order. '-1' — by date updated in chronological order. '-2' — by date created in chronological order. If no sort order is specified, topics are returned in the order specified by the group administrator. Pinned topics are returned first, regardless of the sorting.
    */

--- a/src/methods/database.ts
+++ b/src/methods/database.ts
@@ -93,7 +93,7 @@ export interface DatabaseGetCitiesByIdParams {
   /**
    * City IDs.
    */
-  city_ids?: number[];
+  city_ids?: string;
 }
 
 // database.getCitiesById_response
@@ -143,7 +143,7 @@ export interface DatabaseGetCountriesByIdParams {
   /**
    * Country IDs.
    */
-  country_ids?: number[];
+  country_ids?: string;
 }
 
 // database.getCountriesById_response
@@ -208,7 +208,7 @@ export interface DatabaseGetMetroStationsResponse {
  */
 
 export interface DatabaseGetMetroStationsByIdParams {
-  station_ids?: number[];
+  station_ids?: string;
 }
 
 // database.getMetroStationsById_response

--- a/src/methods/docs.ts
+++ b/src/methods/docs.ts
@@ -75,7 +75,7 @@ export interface DocsEditParams {
   /**
    * Document tags.
    */
-  tags?: string[];
+  tags?: string;
 }
 
 // docs.edit_response
@@ -123,7 +123,7 @@ export interface DocsGetByIdParams {
   /**
    * Document IDs. Example: , "66748_91488,66748_91455",
    */
-  docs: string[];
+  docs: string;
   return_tags?: 0 | 1;
 }
 

--- a/src/methods/donut.ts
+++ b/src/methods/donut.ts
@@ -2,7 +2,6 @@
  * This is auto-generated file, don't modify this file manually
  */
 
-import { BaseUserGroupFields } from '../objects/base/BaseUserGroupFields';
 import { DonutDonatorSubscriptionInfo } from '../objects/donut/DonutDonatorSubscriptionInfo';
 import { GroupsGroupFull } from '../objects/groups/GroupsGroupFull';
 import { GroupsUserXtrRole } from '../objects/groups/GroupsUserXtrRole';
@@ -16,7 +15,7 @@ export interface DonutGetFriendsParams {
   owner_id: number;
   offset?: number;
   count?: number;
-  fields?: string[];
+  fields?: string;
 }
 
 // donut.getFriends_response
@@ -46,7 +45,10 @@ export type DonutGetSubscriptionResponse = DonutDonatorSubscriptionInfo;
  */
 
 export interface DonutGetSubscriptionsParams {
-  fields?: BaseUserGroupFields[];
+  /**
+   * objects.json#/definitions/base_user_group_fields
+   */
+  fields?: string;
   offset?: number;
   count?: number;
 }

--- a/src/methods/fave.ts
+++ b/src/methods/fave.ts
@@ -2,7 +2,6 @@
  * This is auto-generated file, don't modify this file manually
  */
 
-import { BaseUserGroupFields } from '../objects/base/BaseUserGroupFields';
 import { FaveBookmark } from '../objects/fave/FaveBookmark';
 import { FavePage } from '../objects/fave/FavePage';
 import { FaveTag } from '../objects/fave/FaveTag';
@@ -165,7 +164,10 @@ export interface FaveGetPagesParams {
   offset?: number;
   count?: number;
   type?: 'groups' | 'hints' | 'users';
-  fields?: BaseUserGroupFields[];
+  /**
+   * objects.json#/definitions/base_user_group_fields
+   */
+  fields?: string;
   tag_id?: number;
 }
 
@@ -292,7 +294,7 @@ export type FaveRemoveVideoResponse = 1;
  */
 
 export interface FaveReorderTagsParams {
-  ids: number[];
+  ids: string;
 }
 
 // fave.reorderTags_response
@@ -305,7 +307,7 @@ export type FaveReorderTagsResponse = 1;
 export interface FaveSetPageTagsParams {
   user_id?: number;
   group_id?: number;
-  tag_ids?: number[];
+  tag_ids?: string;
 }
 
 // fave.setPageTags_response
@@ -319,7 +321,7 @@ export interface FaveSetTagsParams {
   item_type?: 'article' | 'clip' | 'link' | 'narrative' | 'page' | 'podcast' | 'post' | 'product' | 'video';
   item_owner_id?: number;
   item_id?: number;
-  tag_ids?: number[];
+  tag_ids?: string;
   link_id?: string;
   link_url?: string;
 }

--- a/src/methods/friends.ts
+++ b/src/methods/friends.ts
@@ -10,7 +10,6 @@ import { FriendsRequests } from '../objects/friends/FriendsRequests';
 import { FriendsRequestsXtrMessage } from '../objects/friends/FriendsRequestsXtrMessage';
 import { FriendsUserXtrLists } from '../objects/friends/FriendsUserXtrLists';
 import { FriendsUserXtrPhone } from '../objects/friends/FriendsUserXtrPhone';
-import { UsersFields } from '../objects/users/UsersFields';
 import { UsersUserFull } from '../objects/users/UsersUserFull';
 
 /**
@@ -55,7 +54,7 @@ export interface FriendsAddListParams {
   /**
    * IDs of users to be added to the friend list.
    */
-  user_ids?: number[];
+  user_ids?: string;
 }
 
 // friends.addList_response
@@ -76,7 +75,7 @@ export interface FriendsAreFriendsParams {
   /**
    * IDs of the users whose friendship status to check.
    */
-  user_ids: number[];
+  user_ids: string;
   /**
    * '1' — to return 'sign' field. 'sign' is md5("{id}_{user_id}_{friends_status}_{application_secret}"), where id is current user ID. This field allows to check that data has not been modified by the client. By default: '0'.
    */
@@ -188,7 +187,7 @@ export interface FriendsEditParams {
   /**
    * IDs of the friend lists to which to add the user.
    */
-  list_ids?: number[];
+  list_ids?: string;
 }
 
 // friends.edit_response
@@ -212,15 +211,15 @@ export interface FriendsEditListParams {
   /**
    * IDs of users in the friend list.
    */
-  user_ids?: number[];
+  user_ids?: string;
   /**
    * (Applies if 'user_ids' parameter is not set.), User IDs to add to the friend list.
    */
-  add_user_ids?: number[];
+  add_user_ids?: string;
   /**
    * (Applies if 'user_ids' parameter is not set.), User IDs to delete from the friend list.
    */
-  delete_user_ids?: number[];
+  delete_user_ids?: string;
 }
 
 // friends.editList_response
@@ -255,8 +254,10 @@ export interface FriendsGetParams {
   offset?: number;
   /**
    * Profile fields to return. Sample values: 'uid', 'first_name', 'last_name', 'nickname', 'sex', 'bdate' (birthdate), 'city', 'country', 'timezone', 'photo', 'photo_medium', 'photo_big', 'domain', 'has_mobile', 'rate', 'contacts', 'education'.
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * Case for declension of user name and surname: , 'nom' — nominative (default) , 'gen' — genitive , 'dat' — dative , 'acc' — accusative , 'ins' — instrumental , 'abl' — prepositional
    */
@@ -303,11 +304,13 @@ export interface FriendsGetByPhonesParams {
   /**
    * List of phone numbers in MSISDN format (maximum 1000). Example: "+79219876543,+79111234567"
    */
-  phones?: string[];
+  phones?: string;
   /**
    * Profile fields to return. Sample values: 'nickname', 'screen_name', 'sex', 'bdate' (birthdate), 'city', 'country', 'timezone', 'photo', 'photo_medium', 'photo_big', 'has_mobile', 'rate', 'contacts', 'education', 'online, counters'.
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
 }
 
 // friends.getByPhones_response
@@ -357,7 +360,7 @@ export interface FriendsGetMutualParams {
   /**
    * IDs of the users whose friends will be checked against the friends of the user specified in 'source_uid'.
    */
-  target_uids?: number[];
+  target_uids?: string;
   /**
    * Sort order: 'random' — random order
    */
@@ -473,7 +476,10 @@ export interface FriendsGetRequestsParams {
    */
   suggested?: 0 | 1;
   ref?: string;
-  fields?: UsersFields[];
+  /**
+   * objects.json#/definitions/users_fields
+   */
+  fields?: string;
 }
 
 // friends.getRequests_response
@@ -517,7 +523,7 @@ export interface FriendsGetSuggestionsParams {
   /**
    * Types of potential friends to return: 'mutual' — users with many mutual friends , 'contacts' — users found with the [vk.com/dev/account.importContacts|account.importContacts] method , 'mutual_contacts' — users who imported the same contacts as the current user with the [vk.com/dev/account.importContacts|account.importContacts] method
    */
-  filter?: string[];
+  filter?: string;
   /**
    * Number of suggestions to return.
    */
@@ -528,8 +534,10 @@ export interface FriendsGetSuggestionsParams {
   offset?: number;
   /**
    * Profile fields to return. Sample values: 'nickname', 'screen_name', 'sex', 'bdate' (birthdate), 'city', 'country', 'timezone', 'photo', 'photo_medium', 'photo_big', 'has_mobile', 'rate', 'contacts', 'education', 'online', 'counters'.
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * Case for declension of user name and surname: , 'nom' — nominative (default) , 'gen' — genitive , 'dat' — dative , 'acc' — accusative , 'ins' — instrumental , 'abl' — prepositional
    */
@@ -562,8 +570,10 @@ export interface FriendsSearchParams {
   q?: string;
   /**
    * Profile fields to return. Sample values: 'nickname', 'screen_name', 'sex', 'bdate' (birthdate), 'city', 'country', 'timezone', 'photo', 'photo_medium', 'photo_big', 'has_mobile', 'rate', 'contacts', 'education', 'online',
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * Case for declension of user name and surname: 'nom' — nominative (default), 'gen' — genitive , 'dat' — dative, 'acc' — accusative , 'ins' — instrumental , 'abl' — prepositional
    */

--- a/src/methods/groups.ts
+++ b/src/methods/groups.ts
@@ -2,14 +2,10 @@
  * This is auto-generated file, don't modify this file manually
  */
 
-import { AddressesFields } from '../objects/addresses/AddressesFields';
-import { BaseUserGroupFields } from '../objects/base/BaseUserGroupFields';
 import { GroupsAddress } from '../objects/groups/GroupsAddress';
 import { GroupsBannedItem } from '../objects/groups/GroupsBannedItem';
 import { GroupsCallbackServer } from '../objects/groups/GroupsCallbackServer';
 import { GroupsCallbackSettings } from '../objects/groups/GroupsCallbackSettings';
-import { GroupsFields } from '../objects/groups/GroupsFields';
-import { GroupsFilter } from '../objects/groups/GroupsFilter';
 import { GroupsGroup } from '../objects/groups/GroupsGroup';
 import { GroupsGroupAccess } from '../objects/groups/GroupsGroupAccess';
 import { GroupsGroupAgeLimits } from '../objects/groups/GroupsGroupAgeLimits';
@@ -37,7 +33,6 @@ import { GroupsSettingsTwitter } from '../objects/groups/GroupsSettingsTwitter';
 import { GroupsSubjectItem } from '../objects/groups/GroupsSubjectItem';
 import { GroupsTokenPermissionSetting } from '../objects/groups/GroupsTokenPermissionSetting';
 import { GroupsUserXtrRole } from '../objects/groups/GroupsUserXtrRole';
-import { UsersFields } from '../objects/users/UsersFields';
 import { UsersUserFull } from '../objects/users/UsersUserFull';
 import { UsersUserMin } from '../objects/users/UsersUserMin';
 
@@ -363,11 +358,11 @@ export interface GroupsEditParams {
   /**
    * Market delivery countries.
    */
-  market_country?: number[];
+  market_country?: string;
   /**
    * Market delivery cities (if only one country is specified).
    */
-  market_city?: number[];
+  market_city?: string;
   /**
    * Market currency settings. Possbile values: , *'643' – Russian rubles,, *'980' – Ukrainian hryvnia,, *'398' – Kazakh tenge,, *'978' – Euro,, *'840' – US dollars
    */
@@ -391,7 +386,7 @@ export interface GroupsEditParams {
   /**
    * Keywords for stopwords filter.
    */
-  obscene_words?: string[];
+  obscene_words?: string;
   main_section?: number;
   secondary_section?: number;
   /**
@@ -538,12 +533,16 @@ export interface GroupsGetParams {
   extended?: 0 | 1;
   /**
    * Types of communities to return: 'admin' — to return communities administered by the user , 'editor' — to return communities where the user is an administrator or editor, 'moder' — to return communities where the user is an administrator, editor, or moderator, 'groups' — to return only groups, 'publics' — to return only public pages, 'events' — to return only events
+   *
+   * objects.json#/definitions/groups_filter
    */
-  filter?: GroupsFilter[];
+  filter?: string;
   /**
    * Profile fields to return.
+   *
+   * objects.json#/definitions/groups_fields
    */
-  fields?: GroupsFields[];
+  fields?: string;
   /**
    * Offset needed to return a specific subset of communities.
    */
@@ -583,7 +582,7 @@ export interface GroupsGetAddressesParams {
    * ID or screen name of the community.
    */
   group_id: number;
-  address_ids?: number[];
+  address_ids?: string;
   /**
    * Latitude of  the user geo position.
    */
@@ -602,8 +601,10 @@ export interface GroupsGetAddressesParams {
   count?: number;
   /**
    * Address fields
+   *
+   * objects.json#/definitions/addresses_fields
    */
-  fields?: AddressesFields[];
+  fields?: string;
 }
 
 // groups.getAddresses_response
@@ -634,7 +635,10 @@ export interface GroupsGetBannedParams {
    * Number of users to return.
    */
   count?: number;
-  fields?: BaseUserGroupFields[];
+  /**
+   * objects.json#/definitions/base_user_group_fields
+   */
+  fields?: string;
   owner_id?: number;
 }
 
@@ -657,15 +661,17 @@ export interface GroupsGetByIdParams {
   /**
    * IDs or screen names of communities.
    */
-  group_ids?: string[];
+  group_ids?: string;
   /**
    * ID or screen name of the community.
    */
   group_id?: string;
   /**
    * Group fields to return.
+   *
+   * objects.json#/definitions/groups_fields
    */
-  fields?: GroupsFields[];
+  fields?: string;
 }
 
 // groups.getById_response
@@ -698,7 +704,7 @@ export interface GroupsGetCallbackConfirmationCodeResponse {
 
 export interface GroupsGetCallbackServersParams {
   group_id: number;
-  server_ids?: number[];
+  server_ids?: string;
 }
 
 // groups.getCallbackServers_response
@@ -809,8 +815,10 @@ export interface GroupsGetInvitedUsersParams {
   count?: number;
   /**
    * List of additional fields to be returned. Available values: 'sex, bdate, city, country, photo_50, photo_100, photo_200_orig, photo_200, photo_400_orig, photo_max, photo_max_orig, online, online_mobile, lists, domain, has_mobile, contacts, connections, site, education, universities, schools, can_post, can_see_all_posts, can_see_audio, can_write_private_message, status, last_seen, common_count, relation, relatives, counters'.
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * Case for declension of user name and surname. Possible values: *'nom' — nominative (default),, *'gen' — genitive,, *'dat' — dative,, *'acc' — accusative, , *'ins' — instrumental,, *'abl' — prepositional.
    */
@@ -924,8 +932,10 @@ export interface GroupsGetMembersParams {
   count?: number;
   /**
    * List of additional fields to be returned. Available values: 'sex, bdate, city, country, photo_50, photo_100, photo_200_orig, photo_200, photo_400_orig, photo_max, photo_max_orig, online, online_mobile, lists, domain, has_mobile, contacts, connections, site, education, universities, schools, can_post, can_see_all_posts, can_see_audio, can_write_private_message, status, last_seen, common_count, relation, relatives, counters'.
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * *'friends' – only friends in this community will be returned,, *'unsure' – only those who pressed 'I may attend' will be returned (if it's an event).
    */
@@ -980,8 +990,10 @@ export interface GroupsGetRequestsParams {
   count?: number;
   /**
    * Profile fields to return.
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
 }
 
 // groups.getRequests_response
@@ -1204,7 +1216,7 @@ export interface GroupsIsMemberParams {
   /**
    * User IDs.
    */
-  user_ids?: number[];
+  user_ids?: string;
   /**
    * '1' — to return an extended response with additional fields. By default: '0'.
    */

--- a/src/methods/market.ts
+++ b/src/methods/market.ts
@@ -9,7 +9,6 @@ import { MarketMarketItem } from '../objects/market/MarketMarketItem';
 import { MarketMarketItemFull } from '../objects/market/MarketMarketItemFull';
 import { MarketOrder } from '../objects/market/MarketOrder';
 import { MarketOrderItem } from '../objects/market/MarketOrderItem';
-import { UsersFields } from '../objects/users/UsersFields';
 import { WallWallComment } from '../objects/wall/WallWallComment';
 
 /**
@@ -51,7 +50,7 @@ export interface MarketAddParams {
   /**
    * IDs of additional photos.
    */
-  photo_ids?: number[];
+  photo_ids?: string;
   /**
    * Url for button in market item.
    */
@@ -121,7 +120,7 @@ export interface MarketAddToAlbumParams {
   /**
    * Collections IDs to add item to.
    */
-  album_ids: number[];
+  album_ids: string;
 }
 
 // market.addToAlbum_response
@@ -149,7 +148,7 @@ export interface MarketCreateCommentParams {
   /**
    * Comma-separated list of objects attached to a comment. The field is submitted the following way: , "'<owner_id>_<media_id>,<owner_id>_<media_id>'", , '' - media attachment type: "'photo' - photo, 'video' - video, 'audio' - audio, 'doc' - document", , '<owner_id>' - media owner id, '<media_id>' - media attachment id, , For example: "photo100172_166443618,photo66748_265827614",
    */
-  attachments?: string[];
+  attachments?: string;
   /**
    * '1' - comment will be published on behalf of a community, '0' - on behalf of a user (by default).
    */
@@ -273,7 +272,7 @@ export interface MarketEditParams {
   /**
    * IDs of additional photos.
    */
-  photo_ids?: number[];
+  photo_ids?: string;
   /**
    * Url for button in market item.
    */
@@ -337,7 +336,7 @@ export interface MarketEditCommentParams {
   /**
    * Comma-separated list of objects attached to a comment. The field is submitted the following way: , "'<owner_id>_<media_id>,<owner_id>_<media_id>'", , '' - media attachment type: "'photo' - photo, 'video' - video, 'audio' - audio, 'doc' - document", , '<owner_id>' - media owner id, '<media_id>' - media attachment id, , For example: "photo100172_166443618,photo66748_265827614",
    */
-  attachments?: string[];
+  attachments?: string;
 }
 
 // market.editComment_response
@@ -417,7 +416,7 @@ export interface MarketGetAlbumByIdParams {
   /**
    * collections identifiers to obtain data from
    */
-  album_ids: number[];
+  album_ids: string;
 }
 
 // market.getAlbumById_response
@@ -469,7 +468,7 @@ export interface MarketGetByIdParams {
   /**
    * Comma-separated ids list: {user id}_{item id}. If an item belongs to a community -{community id} is used. " 'Videos' value example: , '-4363_136089719,13245770_137352259'"
    */
-  item_ids: string[];
+  item_ids: string;
   /**
    * '1' – to return additional fields: 'likes, can_comment, car_repost, photos'. By default: '0'.
    */
@@ -554,8 +553,10 @@ export interface MarketGetCommentsParams {
   extended?: 0 | 1;
   /**
    * List of additional profile fields to return. See the [vk.com/dev/fields|details]
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
 }
 
 // market.getComments_response
@@ -673,7 +674,7 @@ export interface MarketRemoveFromAlbumParams {
   /**
    * Collections IDs to remove item from.
    */
-  album_ids: number[];
+  album_ids: string;
 }
 
 // market.removeFromAlbum_response

--- a/src/methods/messages.ts
+++ b/src/methods/messages.ts
@@ -2,7 +2,6 @@
  * This is auto-generated file, don't modify this file manually
  */
 
-import { BaseUserGroupFields } from '../objects/base/BaseUserGroupFields';
 import { GroupsGroup } from '../objects/groups/GroupsGroup';
 import { GroupsGroupFull } from '../objects/groups/GroupsGroupFull';
 import { MessagesChat } from '../objects/messages/MessagesChat';
@@ -18,7 +17,6 @@ import { MessagesLongpollParams } from '../objects/messages/MessagesLongpollPara
 import { MessagesMessage } from '../objects/messages/MessagesMessage';
 import { MessagesMessagesArray } from '../objects/messages/MessagesMessagesArray';
 import { MessagesPinnedMessage } from '../objects/messages/MessagesPinnedMessage';
-import { UsersFields } from '../objects/users/UsersFields';
 import { UsersUser } from '../objects/users/UsersUser';
 import { UsersUserFull } from '../objects/users/UsersUserFull';
 
@@ -70,7 +68,7 @@ export interface MessagesCreateChatParams {
   /**
    * IDs of the users to be added to the chat.
    */
-  user_ids?: number[];
+  user_ids?: string;
   /**
    * Chat title.
    */
@@ -91,7 +89,7 @@ export interface MessagesDeleteParams {
   /**
    * Message IDs.
    */
-  message_ids?: number[];
+  message_ids?: string;
   /**
    * '1' — to mark message as spam.
    */
@@ -262,15 +260,17 @@ export interface MessagesGetByConversationMessageIdParams {
   /**
    * Conversation message IDs.
    */
-  conversation_message_ids: number[];
+  conversation_message_ids: string;
   /**
    * Information whether the response should be extended
    */
   extended?: 0 | 1;
   /**
    * Profile fields to return.
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * Group ID (for group messages with group access token)
    */
@@ -296,7 +296,7 @@ export interface MessagesGetByIdParams {
   /**
    * Message IDs.
    */
-  message_ids: number[];
+  message_ids: string;
   /**
    * Number of characters after which to truncate a previewed message. To preview the full message, specify '0'. "NOTE: Messages are not truncated by default. Messages are truncated by words."
    */
@@ -307,8 +307,10 @@ export interface MessagesGetByIdParams {
   extended?: 0 | 1;
   /**
    * Profile fields to return.
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * Group ID (for group messages with group access token)
    */
@@ -347,8 +349,10 @@ export interface MessagesGetChatPreviewParams {
   link?: string;
   /**
    * Profile fields to return.
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
 }
 
 // messages.getChatPreview_response
@@ -370,8 +374,10 @@ export interface MessagesGetConversationMembersParams {
   peer_id: number;
   /**
    * Profile fields to return.
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * Group ID (for group messages with group access token)
    */
@@ -419,8 +425,10 @@ export interface MessagesGetConversationsParams {
   start_message_id?: number;
   /**
    * Profile and communities fields to return.
+   *
+   * objects.json#/definitions/base_user_group_fields
    */
-  fields?: BaseUserGroupFields[];
+  fields?: string;
   /**
    * Group ID (for group messages with group access token)
    */
@@ -452,15 +460,17 @@ export interface MessagesGetConversationsByIdParams {
   /**
    * Destination IDs. "For user: 'User ID', e.g. '12345'. For chat: '2000000000' + 'chat_id', e.g. '2000000001'. For community: '- community ID', e.g. '-12345'. "
    */
-  peer_ids: number[];
+  peer_ids: string;
   /**
    * Return extended properties
    */
   extended?: 0 | 1;
   /**
    * Profile and communities fields to return.
+   *
+   * objects.json#/definitions/base_user_group_fields
    */
-  fields?: BaseUserGroupFields[];
+  fields?: string;
   /**
    * Group ID (for group messages with group access token)
    */
@@ -520,8 +530,10 @@ export interface MessagesGetHistoryParams {
   extended?: 0 | 1;
   /**
    * Profile fields to return.
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * Group ID (for group messages with group access token)
    */
@@ -577,9 +589,11 @@ export interface MessagesGetHistoryAttachmentsParams {
    */
   photo_sizes?: 0 | 1;
   /**
-   * Additional profile [vk.com/dev/fields|fields] to return. 
+   * Additional profile [vk.com/dev/fields|fields] to return.
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * Group ID (for group messages with group access token)
    */
@@ -616,8 +630,10 @@ export interface MessagesGetImportantMessagesParams {
   preview_length?: number;
   /**
    * Actors fields to return.
+   *
+   * objects.json#/definitions/base_user_group_fields
    */
-  fields?: BaseUserGroupFields[];
+  fields?: string;
   /**
    * Return extended properties
    */
@@ -654,8 +670,8 @@ export interface MessagesGetIntentUsersParams {
   offset?: number;
   count?: number;
   extended?: 0 | 1;
-  name_case?: string[];
-  fields?: string[];
+  name_case?: string;
+  fields?: string;
 }
 
 // messages.getIntentUsers_response
@@ -730,8 +746,10 @@ export interface MessagesGetLongPollHistoryParams {
   onlines?: 0 | 1;
   /**
    * Additional profile [vk.com/dev/fields|fields] to return.
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * Maximum number of events to return.
    */
@@ -869,7 +887,7 @@ export interface MessagesMarkAsImportantParams {
   /**
    * IDs of messages to mark as important.
    */
-  message_ids?: number[];
+  message_ids?: string;
   /**
    * '1' — to add a star (mark as important), '0' — to remove the star
    */
@@ -913,7 +931,7 @@ export interface MessagesMarkAsReadParams {
   /**
    * IDs of messages to mark as read.
    */
-  message_ids?: number[];
+  message_ids?: string;
   /**
    * Destination ID. "For user: 'User ID', e.g. '12345'. For chat: '2000000000' + 'chat_id', e.g. '2000000001'. For community: '- community ID', e.g. '-12345'. "
    */
@@ -1029,7 +1047,7 @@ export interface MessagesSearchParams {
    */
   count?: number;
   extended?: 0 | 1;
-  fields?: string[];
+  fields?: string;
   /**
    * Group ID (for group messages with group access token)
    */
@@ -1078,8 +1096,10 @@ export interface MessagesSearchConversationsParams {
   extended?: 0 | 1;
   /**
    * Profile fields to return.
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * Group ID (for group messages with user access token)
    */
@@ -1119,7 +1139,7 @@ export interface MessagesSendParams {
   /**
    * IDs of message recipients. (See peer_id)
    */
-  peer_ids?: number[];
+  peer_ids?: string;
   /**
    * User's short address (for example, 'illarionov').
    */
@@ -1131,7 +1151,7 @@ export interface MessagesSendParams {
   /**
    * IDs of message recipients (if new conversation shall be started).
    */
-  user_ids?: number[];
+  user_ids?: string;
   /**
    * (Required if 'attachments' is not set.) Text of the message.
    */
@@ -1152,7 +1172,7 @@ export interface MessagesSendParams {
   /**
    * ID of forwarded messages, separated with a comma. Listed messages of the sender will be shown in the message body at the recipient's. Example: "123,431,544"
    */
-  forward_messages?: number[];
+  forward_messages?: string;
   /**
    * JSON describing the forwarded message or reply
    */

--- a/src/methods/newsfeed.ts
+++ b/src/methods/newsfeed.ts
@@ -2,14 +2,10 @@
  * This is auto-generated file, don't modify this file manually
  */
 
-import { BaseUserGroupFields } from '../objects/base/BaseUserGroupFields';
 import { GroupsGroupFull } from '../objects/groups/GroupsGroupFull';
-import { NewsfeedCommentsFilters } from '../objects/newsfeed/NewsfeedCommentsFilters';
-import { NewsfeedFilters } from '../objects/newsfeed/NewsfeedFilters';
 import { NewsfeedList } from '../objects/newsfeed/NewsfeedList';
 import { NewsfeedListFull } from '../objects/newsfeed/NewsfeedListFull';
 import { NewsfeedNewsfeedItem } from '../objects/newsfeed/NewsfeedNewsfeedItem';
-import { UsersFields } from '../objects/users/UsersFields';
 import { UsersSubscriptionsItem } from '../objects/users/UsersSubscriptionsItem';
 import { UsersUserFull } from '../objects/users/UsersUserFull';
 import { WallWallpostFull } from '../objects/wall/WallWallpostFull';
@@ -22,8 +18,8 @@ import { WallWallpostToId } from '../objects/wall/WallWallpostToId';
  */
 
 export interface NewsfeedAddBanParams {
-  user_ids?: number[];
-  group_ids?: number[];
+  user_ids?: string;
+  group_ids?: string;
 }
 
 // newsfeed.addBan_response
@@ -36,8 +32,8 @@ export type NewsfeedAddBanResponse = 1;
  */
 
 export interface NewsfeedDeleteBanParams {
-  user_ids?: number[];
-  group_ids?: number[];
+  user_ids?: string;
+  group_ids?: string;
 }
 
 // newsfeed.deleteBan_response
@@ -63,8 +59,10 @@ export type NewsfeedDeleteListResponse = 1;
 export interface NewsfeedGetParams {
   /**
    * Filters to apply: 'post' — new wall posts, 'photo' — new photos, 'photo_tag' — new photo tags, 'wall_photo' — new wall photos, 'friend' — new friends
+   *
+   * objects.json#/definitions/newsfeed_filters
    */
-  filters?: NewsfeedFilters[];
+  filters?: string;
   /**
    * '1' — to return news items from banned sources
    */
@@ -95,8 +93,10 @@ export interface NewsfeedGetParams {
   count?: number;
   /**
    * Additional fields of [vk.com/dev/fields|profiles] and [vk.com/dev/fields_groups|communities] to return.
+   *
+   * objects.json#/definitions/base_user_group_fields
    */
-  fields?: BaseUserGroupFields[];
+  fields?: string;
   section?: string;
 }
 
@@ -124,8 +124,10 @@ export interface NewsfeedGetBannedParams {
   extended?: 0 | 1;
   /**
    * Profile fields to return.
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * Case for declension of user name and surname: 'nom' — nominative (default), 'gen' — genitive , 'dat' — dative, 'acc' — accusative , 'ins' — instrumental , 'abl' — prepositional
    */
@@ -157,8 +159,10 @@ export interface NewsfeedGetCommentsParams {
   count?: number;
   /**
    * Filters to apply: 'post' — new comments on wall posts, 'photo' — new comments on photos, 'video' — new comments on videos, 'topic' — new comments on discussions, 'note' — new comments on notes,
+   *
+   * objects.json#/definitions/newsfeed_comments_filters
    */
-  filters?: NewsfeedCommentsFilters[];
+  filters?: string;
   /**
    * Object ID, comments on repost of which shall be returned, e.g. 'wall1_45486'. (If the parameter is set, the 'filters' parameter is optional.),
    */
@@ -178,8 +182,10 @@ export interface NewsfeedGetCommentsParams {
   start_from?: string;
   /**
    * Additional fields of [vk.com/dev/fields|profiles] and [vk.com/dev/fields_groups|communities] to return.
+   *
+   * objects.json#/definitions/base_user_group_fields
    */
-  fields?: BaseUserGroupFields[];
+  fields?: string;
 }
 
 // newsfeed.getComments_response
@@ -203,7 +209,7 @@ export interface NewsfeedGetListsParams {
   /**
    * numeric list identifiers.
    */
-  list_ids?: number[];
+  list_ids?: string;
   /**
    * Return additional list info
    */
@@ -295,8 +301,10 @@ export interface NewsfeedGetRecommendedParams {
   count?: number;
   /**
    * Additional fields of [vk.com/dev/fields|profiles] and [vk.com/dev/fields_groups|communities] to return.
+   *
+   * objects.json#/definitions/base_user_group_fields
    */
-  fields?: BaseUserGroupFields[];
+  fields?: string;
 }
 
 // newsfeed.getRecommended_response
@@ -331,8 +339,10 @@ export interface NewsfeedGetSuggestedSourcesParams {
   shuffle?: 0 | 1;
   /**
    * list of extra fields to be returned. See available fields for [vk.com/dev/fields|users] and [vk.com/dev/fields_groups|communities].
+   *
+   * objects.json#/definitions/base_user_group_fields
    */
-  fields?: BaseUserGroupFields[];
+  fields?: string;
 }
 
 // newsfeed.getSuggestedSources_response
@@ -386,7 +396,7 @@ export interface NewsfeedSaveListParams {
   /**
    * users and communities identifiers to be added to the list. Community identifiers must be negative numbers.
    */
-  source_ids?: number[];
+  source_ids?: string;
   /**
    * reposts display on and off ('1' is for off).
    */
@@ -434,8 +444,10 @@ export interface NewsfeedSearchParams {
   start_from?: string;
   /**
    * Additional fields of [vk.com/dev/fields|profiles] and [vk.com/dev/fields_groups|communities] to return.
+   *
+   * objects.json#/definitions/base_user_group_fields
    */
-  fields?: BaseUserGroupFields[];
+  fields?: string;
 }
 
 // newsfeed.search_response

--- a/src/methods/notes.ts
+++ b/src/methods/notes.ts
@@ -20,8 +20,8 @@ export interface NotesAddParams {
    * Note text.
    */
   text: string;
-  privacy_view?: string[];
-  privacy_comment?: string[];
+  privacy_view?: string;
+  privacy_comment?: string;
 }
 
 // notes.add_response
@@ -111,8 +111,8 @@ export interface NotesEditParams {
    * Note text.
    */
   text: string;
-  privacy_view?: string[];
-  privacy_comment?: string[];
+  privacy_view?: string;
+  privacy_comment?: string;
 }
 
 // notes.edit_response
@@ -152,7 +152,7 @@ export interface NotesGetParams {
   /**
    * Note IDs.
    */
-  note_ids?: number[];
+  note_ids?: string;
   /**
    * Note owner ID.
    */

--- a/src/methods/notifications.ts
+++ b/src/methods/notifications.ts
@@ -25,7 +25,7 @@ export interface NotificationsGetParams {
   /**
    * Type of notifications to return: 'wall' — wall posts, 'mentions' — mentions in wall posts, comments, or topics, 'comments' — comments to wall posts, photos, and videos, 'likes' — likes, 'reposted' — wall posts that are copied from the current user's wall, 'followers' — new followers, 'friends' — accepted friend requests
    */
-  filters?: string[];
+  filters?: string;
   /**
    * Earliest timestamp (in Unix time) of a notification to return. By default, 24 hours ago.
    */
@@ -72,7 +72,7 @@ export type NotificationsMarkAsViewedResponse = 0 | 1;
  */
 
 export interface NotificationsSendMessageParams {
-  user_ids: number[];
+  user_ids: string;
   message: string;
   fragment?: string;
   group_id?: number;

--- a/src/methods/orders.ts
+++ b/src/methods/orders.ts
@@ -74,7 +74,7 @@ export type OrdersGetResponse = OrdersOrder[];
 
 export interface OrdersGetAmountParams {
   user_id: number;
-  votes: string[];
+  votes: string;
 }
 
 // orders.getAmount_response
@@ -94,7 +94,7 @@ export interface OrdersGetByIdParams {
   /**
    * order IDs (when information about several orders is requested).
    */
-  order_ids?: number[];
+  order_ids?: string;
   /**
    * if this parameter is set to 1, this method returns a list of test mode orders. By default — 0.
    */

--- a/src/methods/photos.ts
+++ b/src/methods/photos.ts
@@ -14,7 +14,6 @@ import { PhotosPhotoTag } from '../objects/photos/PhotosPhotoTag';
 import { PhotosPhotoUpload } from '../objects/photos/PhotosPhotoUpload';
 import { PhotosPhotoXtrRealOffset } from '../objects/photos/PhotosPhotoXtrRealOffset';
 import { PhotosPhotoXtrTagInfo } from '../objects/photos/PhotosPhotoXtrTagInfo';
-import { UsersFields } from '../objects/users/UsersFields';
 import { UsersUserFull } from '../objects/users/UsersUserFull';
 import { WallWallComment } from '../objects/wall/WallWallComment';
 
@@ -85,8 +84,8 @@ export interface PhotosCreateAlbumParams {
    * Album description.
    */
   description?: string;
-  privacy_view?: string[];
-  privacy_comment?: string[];
+  privacy_view?: string;
+  privacy_comment?: string;
   upload_by_admins_only?: 0 | 1;
   comments_disabled?: 0 | 1;
 }
@@ -116,7 +115,7 @@ export interface PhotosCreateCommentParams {
   /**
    * (Required if 'message' is not set.) List of objects attached to the post, in the following format: "<owner_id>_<media_id>,<owner_id>_<media_id>", '' — Type of media attachment: 'photo' — photo, 'video' — video, 'audio' — audio, 'doc' — document, '<owner_id>' — Media attachment owner ID. '<media_id>' — Media attachment ID. Example: "photo100172_166443618,photo66748_265827614"
    */
-  attachments?: string[];
+  attachments?: string;
   /**
    * '1' — to post a comment from the community
    */
@@ -242,8 +241,8 @@ export interface PhotosEditAlbumParams {
    * ID of the user or community that owns the album.
    */
   owner_id?: number;
-  privacy_view?: string[];
-  privacy_comment?: string[];
+  privacy_view?: string;
+  privacy_comment?: string;
   upload_by_admins_only?: 0 | 1;
   comments_disabled?: 0 | 1;
 }
@@ -273,7 +272,7 @@ export interface PhotosEditCommentParams {
   /**
    * (Required if 'message' is not set.) List of objects attached to the post, in the following format: "<owner_id>_<media_id>,<owner_id>_<media_id>", '' — Type of media attachment: 'photo' — photo, 'video' — video, 'audio' — audio, 'doc' — document, '<owner_id>' — Media attachment owner ID. '<media_id>' — Media attachment ID. Example: "photo100172_166443618,photo66748_265827614"
    */
-  attachments?: string[];
+  attachments?: string;
 }
 
 // photos.editComment_response
@@ -297,7 +296,7 @@ export interface PhotosGetParams {
   /**
    * Photo IDs.
    */
-  photo_ids?: string[];
+  photo_ids?: string;
   /**
    * Sort order: '1' — reverse chronological, '0' — chronological
    */
@@ -354,7 +353,7 @@ export interface PhotosGetAlbumsParams {
   /**
    * Album IDs.
    */
-  album_ids?: number[];
+  album_ids?: string;
   /**
    * Offset needed to return a specific subset of albums.
    */
@@ -521,7 +520,7 @@ export interface PhotosGetByIdParams {
   /**
    * IDs separated with a comma, that are IDs of users who posted photos and IDs of photos themselves with an underscore character between such IDs. To get information about a photo in the group album, you shall specify group ID instead of user ID. Example: "1_129207899,6492_135055734, , -20629724_271945303"
    */
-  photos: string[];
+  photos: string;
   /**
    * '1' — to return additional fields, '0' — (default)
    */
@@ -594,7 +593,10 @@ export interface PhotosGetCommentsParams {
   sort?: 'asc' | 'desc';
   access_key?: string;
   extended?: 0 | 1;
-  fields?: UsersFields[];
+  /**
+   * objects.json#/definitions/users_fields
+   */
+  fields?: string;
 }
 
 // photos.getComments_response

--- a/src/methods/polls.ts
+++ b/src/methods/polls.ts
@@ -6,7 +6,6 @@ import { BaseUploadServer } from '../objects/base/BaseUploadServer';
 import { PollsBackground } from '../objects/polls/PollsBackground';
 import { PollsPoll } from '../objects/polls/PollsPoll';
 import { PollsVoters } from '../objects/polls/PollsVoters';
-import { UsersFields } from '../objects/users/UsersFields';
 
 /**
  * polls.addVote
@@ -23,7 +22,7 @@ export interface PollsAddVoteParams {
    * Poll ID.
    */
   poll_id: number;
-  answer_ids: number[];
+  answer_ids: string;
   is_board?: 0 | 1;
 }
 
@@ -157,7 +156,7 @@ export interface PollsGetByIdParams {
   poll_id: number;
   extended?: 0 | 1;
   friends_count?: number;
-  fields?: string[];
+  fields?: string;
   name_case?: 'abl' | 'acc' | 'dat' | 'gen' | 'ins' | 'nom';
 }
 
@@ -193,7 +192,7 @@ export interface PollsGetVotersParams {
   /**
    * Answer IDs.
    */
-  answer_ids: number[];
+  answer_ids: string;
   is_board?: 0 | 1;
   /**
    * '1' — to return only current user's friends, '0' — to return all users (default),
@@ -209,8 +208,10 @@ export interface PollsGetVotersParams {
   count?: number;
   /**
    * Profile fields to return. Sample values: 'nickname', 'screen_name', 'sex', 'bdate (birthdate)', 'city', 'country', 'timezone', 'photo', 'photo_medium', 'photo_big', 'has_mobile', 'rate', 'contacts', 'education', 'online', 'counters'.
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * Case for declension of user name and surname: , 'nom' — nominative (default) , 'gen' — genitive , 'dat' — dative , 'acc' — accusative , 'ins' — instrumental , 'abl' — prepositional
    */

--- a/src/methods/prettyCards.ts
+++ b/src/methods/prettyCards.ts
@@ -107,7 +107,7 @@ export interface PrettyCardsGetResponse {
 
 export interface PrettyCardsGetByIdParams {
   owner_id: number;
-  card_ids: number[];
+  card_ids: string;
 }
 
 // prettyCards.getById_response

--- a/src/methods/search.ts
+++ b/src/methods/search.ts
@@ -23,8 +23,8 @@ export interface SearchGetHintsParams {
    * Maximum number of results to return.
    */
   limit?: number;
-  filters?: string[];
-  fields?: string[];
+  filters?: string;
+  fields?: string;
   search_global?: 0 | 1;
 }
 

--- a/src/methods/secure.ts
+++ b/src/methods/secure.ts
@@ -112,7 +112,7 @@ export type SecureGetTransactionsHistoryResponse = SecureTransaction[];
  */
 
 export interface SecureGetUserLevelParams {
-  user_ids: number[];
+  user_ids: string;
 }
 
 // secure.getUserLevel_response
@@ -125,7 +125,7 @@ export type SecureGetUserLevelResponse = SecureLevel[];
  */
 
 export interface SecureGiveEventStickerParams {
-  user_ids: number[];
+  user_ids: string;
   achievement_id: number;
 }
 
@@ -139,7 +139,7 @@ export type SecureGiveEventStickerResponse = {}[];
  */
 
 export interface SecureSendNotificationParams {
-  user_ids?: number[];
+  user_ids?: string;
   user_id?: number;
   /**
    * notification text which should be sent in 'UTF-8' encoding ('254' characters maximum).
@@ -177,7 +177,7 @@ export type SecureSendSMSNotificationResponse = 1;
  */
 
 export interface SecureSetCounterParams {
-  counters?: string[];
+  counters?: string;
   user_id?: number;
   /**
    * counter value.

--- a/src/methods/stats.ts
+++ b/src/methods/stats.ts
@@ -24,8 +24,8 @@ export interface StatsGetParams {
   timestamp_to?: number;
   interval?: 'all' | 'day' | 'month' | 'week' | 'year';
   intervals_count?: number;
-  filters?: string[];
-  stats_groups?: string[];
+  filters?: string;
+  stats_groups?: string;
   extended?: 0 | 1;
 }
 
@@ -46,7 +46,7 @@ export interface StatsGetPostReachParams {
   /**
    * wall posts id
    */
-  post_ids: number[];
+  post_ids: string;
 }
 
 // stats.getPostReach_response

--- a/src/methods/storage.ts
+++ b/src/methods/storage.ts
@@ -12,7 +12,7 @@ import { StorageValue } from '../objects/storage/StorageValue';
 
 export interface StorageGetParams {
   key?: string;
-  keys?: string[];
+  keys?: string;
   user_id?: number;
 }
 

--- a/src/methods/store.ts
+++ b/src/methods/store.ts
@@ -16,7 +16,7 @@ export interface StoreAddStickersToFavoriteParams {
   /**
    * Sticker IDs to be added
    */
-  sticker_ids: number[];
+  sticker_ids: string;
 }
 
 // store.addStickersToFavorite_response
@@ -39,8 +39,8 @@ export interface StoreGetProductsParams {
   type?: string;
   merchant?: string;
   section?: string;
-  product_ids?: number[];
-  filters?: string[];
+  product_ids?: string;
+  filters?: string;
   extended?: 0 | 1;
 }
 
@@ -52,8 +52,8 @@ export type StoreGetProductsResponse = StoreProduct[];
  */
 
 export interface StoreGetStickersKeywordsParams {
-  stickers_ids?: number[];
-  products_ids?: number[];
+  stickers_ids?: string;
+  products_ids?: string;
   aliases?: 0 | 1;
   all_products?: 0 | 1;
   need_stickers?: 0 | 1;
@@ -83,7 +83,7 @@ export interface StoreRemoveStickersFromFavoriteParams {
   /**
    * Sticker IDs to be removed
    */
-  sticker_ids: number[];
+  sticker_ids: string;
 }
 
 // store.removeStickersFromFavorite_response

--- a/src/methods/stories.ts
+++ b/src/methods/stories.ts
@@ -2,7 +2,6 @@
  * This is auto-generated file, don't modify this file manually
  */
 
-import { BaseUserGroupFields } from '../objects/base/BaseUserGroupFields';
 import { GroupsGroup } from '../objects/groups/GroupsGroup';
 import { GroupsGroupFull } from '../objects/groups/GroupsGroupFull';
 import { StoriesFeedItem } from '../objects/stories/StoriesFeedItem';
@@ -22,7 +21,7 @@ export interface StoriesBanOwnerParams {
   /**
    * List of sources IDs
    */
-  owners_ids: number[];
+  owners_ids: string;
 }
 
 // stories.banOwner_response
@@ -43,7 +42,7 @@ export interface StoriesDeleteParams {
    * Story ID.
    */
   story_id?: number;
-  stories?: string[];
+  stories?: string;
 }
 
 // stories.delete_response
@@ -64,7 +63,10 @@ export interface StoriesGetParams {
    * '1' — to return additional fields for users and communities. Default value is 0.
    */
   extended?: 0 | 1;
-  fields?: BaseUserGroupFields[];
+  /**
+   * objects.json#/definitions/base_user_group_fields
+   */
+  fields?: string;
 }
 
 // stories.get_response
@@ -89,8 +91,10 @@ export interface StoriesGetBannedParams {
   extended?: 0 | 1;
   /**
    * Additional fields to return
+   *
+   * objects.json#/definitions/base_user_group_fields
    */
-  fields?: BaseUserGroupFields[];
+  fields?: string;
 }
 
 // stories.getBanned_response
@@ -123,15 +127,17 @@ export interface StoriesGetByIdParams {
   /**
    * Stories IDs separated by commas. Use format {owner_id}+'_'+{story_id}, for example, 12345_54331.
    */
-  stories: string[];
+  stories: string;
   /**
    * '1' — to return additional fields for users and communities. Default value is 0.
    */
   extended?: 0 | 1;
   /**
    * Additional fields to return
+   *
+   * objects.json#/definitions/base_user_group_fields
    */
-  fields?: BaseUserGroupFields[];
+  fields?: string;
 }
 
 // stories.getById_response
@@ -168,7 +174,7 @@ export interface StoriesGetPhotoUploadServerParams {
   /**
    * List of users IDs who can see the story.
    */
-  user_ids?: number[];
+  user_ids?: string;
   /**
    * ID of the story to reply with the current.
    */
@@ -225,8 +231,10 @@ export interface StoriesGetRepliesParams {
   extended?: 0 | 1;
   /**
    * Additional fields to return
+   *
+   * objects.json#/definitions/base_user_group_fields
    */
-  fields?: BaseUserGroupFields[];
+  fields?: string;
 }
 
 // stories.getReplies_response
@@ -246,7 +254,7 @@ export interface StoriesGetRepliesResponse {
 
 export interface StoriesGetStatsParams {
   /**
-   * Story owner ID. 
+   * Story owner ID.
    */
   owner_id: number;
   /**
@@ -272,7 +280,7 @@ export interface StoriesGetVideoUploadServerParams {
   /**
    * List of users IDs who can see the story.
    */
-  user_ids?: number[];
+  user_ids?: string;
   /**
    * ID of the story to reply with the current.
    */
@@ -395,7 +403,7 @@ export type StoriesHideReplyResponse = 1;
  */
 
 export interface StoriesSaveParams {
-  upload_results: string[];
+  upload_results: string;
 }
 
 // stories.save_response
@@ -417,7 +425,7 @@ export interface StoriesSearchParams {
   mentioned_id?: number;
   count?: number;
   extended?: 0 | 1;
-  fields?: string[];
+  fields?: string;
 }
 
 // stories.search_response
@@ -454,7 +462,7 @@ export interface StoriesUnbanOwnerParams {
   /**
    * List of hidden sources to show stories from.
    */
-  owners_ids: number[];
+  owners_ids: string;
 }
 
 // stories.unbanOwner_response

--- a/src/methods/users.ts
+++ b/src/methods/users.ts
@@ -3,7 +3,6 @@
  */
 
 import { GroupsGroupsArray } from '../objects/groups/GroupsGroupsArray';
-import { UsersFields } from '../objects/users/UsersFields';
 import { UsersSubscriptionsItem } from '../objects/users/UsersSubscriptionsItem';
 import { UsersUserFull } from '../objects/users/UsersUserFull';
 import { UsersUsersArray } from '../objects/users/UsersUsersArray';
@@ -19,11 +18,13 @@ export interface UsersGetParams {
   /**
    * User IDs or screen names ('screen_name'). By default, current user ID.
    */
-  user_ids?: string[];
+  user_ids?: string;
   /**
    * Profile fields to return. Sample values: 'nickname', 'screen_name', 'sex', 'bdate' (birthdate), 'city', 'country', 'timezone', 'photo', 'photo_medium', 'photo_big', 'has_mobile', 'contacts', 'education', 'online', 'counters', 'relation', 'last_seen', 'activity', 'can_write_private_message', 'can_see_all_posts', 'can_post', 'universities', 'can_invite_to_chats'
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * Case for declension of user name and surname: 'nom' — nominative (default), 'gen' — genitive , 'dat' — dative, 'acc' — accusative , 'ins' — instrumental , 'abl' — prepositional
    */
@@ -54,8 +55,10 @@ export interface UsersGetFollowersParams {
   count?: number;
   /**
    * Profile fields to return. Sample values: 'nickname', 'screen_name', 'sex', 'bdate' (birthdate), 'city', 'country', 'timezone', 'photo', 'photo_medium', 'photo_big', 'has_mobile', 'rate', 'contacts', 'education', 'online'.
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * Case for declension of user name and surname: 'nom' — nominative (default), 'gen' — genitive , 'dat' — dative, 'acc' — accusative , 'ins' — instrumental , 'abl' — prepositional
    */
@@ -103,7 +106,10 @@ export interface UsersGetSubscriptionsParams {
    * Number of users and communities to return.
    */
   count?: number;
-  fields?: UsersFields[];
+  /**
+   * objects.json#/definitions/users_fields
+   */
+  fields?: string;
 }
 
 // users.getSubscriptions_response
@@ -170,8 +176,10 @@ export interface UsersSearchParams {
   count?: number;
   /**
    * Profile fields to return. Sample values: 'nickname', 'screen_name', 'sex', 'bdate' (birthdate), 'city', 'country', 'timezone', 'photo', 'photo_medium', 'photo_big', 'has_mobile', 'rate', 'contacts', 'education', 'online',
+   *
+   * objects.json#/definitions/users_fields
    */
-  fields?: UsersFields[];
+  fields?: string;
   /**
    * City ID.
    */
@@ -273,7 +281,7 @@ export interface UsersSearchParams {
    * ID of a community to search in communities.
    */
   group_id?: number;
-  from_list?: string[];
+  from_list?: string;
 }
 
 // users.search_response

--- a/src/methods/video.ts
+++ b/src/methods/video.ts
@@ -52,7 +52,7 @@ export interface VideoAddAlbumParams {
   /**
    * new access permissions for the album. Possible values: , *'0' – all users,, *'1' – friends only,, *'2' – friends and friends of friends,, *'3' – "only me".
    */
-  privacy?: string[];
+  privacy?: string;
 }
 
 // video.addAlbum_response
@@ -70,7 +70,7 @@ export interface VideoAddAlbumResponse {
 export interface VideoAddToAlbumParams {
   target_id?: number;
   album_id?: number;
-  album_ids?: number[];
+  album_ids?: string;
   owner_id: number;
   video_id: number;
 }
@@ -100,7 +100,7 @@ export interface VideoCreateCommentParams {
   /**
    * List of objects attached to the comment, in the following format: "<owner_id>_<media_id>,<owner_id>_<media_id>", '' — Type of media attachment: 'photo' — photo, 'video' — video, 'audio' — audio, 'doc' — document, '<owner_id>' — ID of the media attachment owner. '<media_id>' — Media attachment ID. Example: "photo100172_166443618,photo66748_265827614"
    */
-  attachments?: string[];
+  attachments?: string;
   /**
    * '1' — to post the comment from a community name (only if 'owner_id'<0)
    */
@@ -200,11 +200,11 @@ export interface VideoEditParams {
   /**
    * Privacy settings in a [vk.com/dev/privacy_setting|special format]. Privacy setting is available for videos uploaded to own profile by user.
    */
-  privacy_view?: string[];
+  privacy_view?: string;
   /**
    * Privacy settings for comments in a [vk.com/dev/privacy_setting|special format].
    */
-  privacy_comment?: string[];
+  privacy_comment?: string;
   /**
    * Disable comments for the group video.
    */
@@ -240,7 +240,7 @@ export interface VideoEditAlbumParams {
   /**
    * new access permissions for the album. Possible values: , *'0' – all users,, *'1' – friends only,, *'2' – friends and friends of friends,, *'3' – "only me".
    */
-  privacy?: string[];
+  privacy?: string;
 }
 
 // video.editAlbum_response
@@ -268,7 +268,7 @@ export interface VideoEditCommentParams {
   /**
    * List of objects attached to the comment, in the following format: "<owner_id>_<media_id>,<owner_id>_<media_id>", '' — Type of media attachment: 'photo' — photo, 'video' — video, 'audio' — audio, 'doc' — document, '<owner_id>' — ID of the media attachment owner. '<media_id>' — Media attachment ID. Example: "photo100172_166443618,photo66748_265827614"
    */
-  attachments?: string[];
+  attachments?: string;
 }
 
 // video.editComment_response
@@ -288,7 +288,7 @@ export interface VideoGetParams {
   /**
    * Video IDs, in the following format: "<owner_id>_<media_id>,<owner_id>_<media_id>", Use a negative value to designate a community ID. Example: "-4363_136089719,13245770_137352259"
    */
-  videos?: string[];
+  videos?: string;
   /**
    * ID of the album containing the video(s).
    */
@@ -447,7 +447,7 @@ export interface VideoGetCommentsParams {
    */
   sort?: 'asc' | 'desc';
   extended?: 0 | 1;
-  fields?: string[];
+  fields?: string;
 }
 
 // video.getComments_response
@@ -477,7 +477,7 @@ export interface VideoGetCommentsExtendedResponse {
 export interface VideoRemoveFromAlbumParams {
   target_id?: number;
   album_id?: number;
-  album_ids?: number[];
+  album_ids?: string;
   owner_id: number;
   video_id: number;
 }
@@ -688,8 +688,8 @@ export interface VideoSaveParams {
    * ID of the album to which the saved video will be added.
    */
   album_id?: number;
-  privacy_view?: string[];
-  privacy_comment?: string[];
+  privacy_view?: string;
+  privacy_comment?: string;
   no_comments?: 0 | 1;
   /**
    * '1' — to repeat the playback of the video, '0' — to play the video once,
@@ -727,7 +727,7 @@ export interface VideoSearchParams {
   /**
    * Filters to apply: 'youtube' — return YouTube videos only, 'vimeo' — return Vimeo videos only, 'short' — return short videos only, 'long' — return long videos only
    */
-  filters?: string[];
+  filters?: string;
   search_own?: 0 | 1;
   /**
    * Offset needed to return a specific subset of videos.

--- a/src/methods/wall.ts
+++ b/src/methods/wall.ts
@@ -2,7 +2,6 @@
  * This is auto-generated file, don't modify this file manually
  */
 
-import { BaseUserGroupFields } from '../objects/base/BaseUserGroupFields';
 import { GroupsGroup } from '../objects/groups/GroupsGroup';
 import { GroupsGroupFull } from '../objects/groups/GroupsGroupFull';
 import { UsersUser } from '../objects/users/UsersUser';
@@ -63,7 +62,7 @@ export interface WallCreateCommentParams {
   /**
    * (Required if 'message' is not set.) List of media objects attached to the comment, in the following format: "<owner_id>_<media_id>,<owner_id>_<media_id>", '' — Type of media ojbect: 'photo' — photo, 'video' — video, 'audio' — audio, 'doc' — document, '<owner_id>' — ID of the media owner. '<media_id>' — Media ID. For example: "photo100172_166443618,photo66748_265827614"
    */
-  attachments?: string[];
+  attachments?: string;
   /**
    * Sticker ID.
    */
@@ -142,7 +141,7 @@ export interface WallEditParams {
   /**
    * (Required if 'message' is not set.) List of objects attached to the post, in the following format: "<owner_id>_<media_id>,<owner_id>_<media_id>", '' — Type of media attachment: 'photo' — photo, 'video' — video, 'audio' — audio, 'doc' — document, '<owner_id>' — ID of the media application owner. '<media_id>' — Media application ID. Example: "photo100172_166443618,photo66748_265827614", May contain a link to an external page to include in the post. Example: "photo66748_265827614,http://habrahabr.ru", "NOTE: If more than one link is being attached, an error is thrown."
    */
-  attachments?: string[];
+  attachments?: string;
   services?: string;
   signed?: 0 | 1;
   publish_date?: number;
@@ -188,7 +187,7 @@ export interface WallEditAdsStealthParams {
   /**
    * (Required if 'message' is not set.) List of objects attached to the post, in the following format: "<owner_id>_<media_id>,<owner_id>_<media_id>", '' — Type of media attachment: 'photo' — photo, 'video' — video, 'audio' — audio, 'doc' — document, 'page' — wiki-page, 'note' — note, 'poll' — poll, 'album' — photo album, '<owner_id>' — ID of the media application owner. '<media_id>' — Media application ID. Example: "photo100172_166443618,photo66748_265827614", May contain a link to an external page to include in the post. Example: "photo66748_265827614,http://habrahabr.ru", "NOTE: If more than one link is being attached, an error will be thrown."
    */
-  attachments?: string[];
+  attachments?: string;
   /**
    * Only for posts in communities with 'from_group' set to '1': '1' — post will be signed with the name of the posting user, '0' — post will not be signed (default)
    */
@@ -248,7 +247,7 @@ export interface WallEditCommentParams {
   /**
    * List of objects attached to the comment, in the following format: , "<owner_id>_<media_id>,<owner_id>_<media_id>", '' — Type of media attachment: 'photo' — photo, 'video' — video, 'audio' — audio, 'doc' — document, '<owner_id>' — ID of the media attachment owner. '<media_id>' — Media attachment ID. For example: "photo100172_166443618,photo66748_265827614"
    */
-  attachments?: string[];
+  attachments?: string;
 }
 
 // wall.editComment_response
@@ -285,7 +284,10 @@ export interface WallGetParams {
    * '1' — to return 'wall', 'profiles', and 'groups' fields, '0' — to return no additional fields (default)
    */
   extended?: 0 | 1;
-  fields?: BaseUserGroupFields[];
+  /**
+   * objects.json#/definitions/base_user_group_fields
+   */
+  fields?: string;
 }
 
 // wall.get_response
@@ -318,7 +320,7 @@ export interface WallGetByIdParams {
   /**
    * User or community IDs and post IDs, separated by underscores. Use a negative value to designate a community ID. Example: "93388_21539,93388_20904,2943_4276,-1_1"
    */
-  posts: string[];
+  posts: string;
   /**
    * '1' — to return user and community objects needed to display posts, '0' — no additional fields are returned (default)
    */
@@ -327,7 +329,10 @@ export interface WallGetByIdParams {
    * Sets the number of parent elements to include in the array 'copy_history' that is returned if the post is a repost from another wall.
    */
   copy_history_depth?: number;
-  fields?: BaseUserGroupFields[];
+  /**
+   * objects.json#/definitions/base_user_group_fields
+   */
+  fields?: string;
 }
 
 // wall.getById_response
@@ -356,7 +361,10 @@ export interface WallGetCommentParams {
    */
   comment_id: number;
   extended?: 0 | 1;
-  fields?: BaseUserGroupFields[];
+  /**
+   * objects.json#/definitions/base_user_group_fields
+   */
+  fields?: string;
 }
 
 // wall.getComment_response
@@ -408,7 +416,10 @@ export interface WallGetCommentsParams {
    */
   preview_length?: number;
   extended?: 0 | 1;
-  fields?: BaseUserGroupFields[];
+  /**
+   * objects.json#/definitions/base_user_group_fields
+   */
+  fields?: string;
   /**
    * Comment ID.
    */
@@ -554,7 +565,7 @@ export interface WallPostParams {
   /**
    * (Required if 'message' is not set.) List of objects attached to the post, in the following format: "<owner_id>_<media_id>,<owner_id>_<media_id>", '' — Type of media attachment: 'photo' — photo, 'video' — video, 'audio' — audio, 'doc' — document, 'page' — wiki-page, 'note' — note, 'poll' — poll, 'album' — photo album, '<owner_id>' — ID of the media application owner. '<media_id>' — Media application ID. Example: "photo100172_166443618,photo66748_265827614", May contain a link to an external page to include in the post. Example: "photo66748_265827614,http://habrahabr.ru", "NOTE: If more than one link is being attached, an error will be thrown."
    */
-  attachments?: string[];
+  attachments?: string;
   /**
    * List of services or websites the update will be exported to, if the user has so requested. Sample values: 'twitter', 'facebook'.
    */
@@ -617,7 +628,7 @@ export interface WallPostAdsStealthParams {
   /**
    * (Required if 'message' is not set.) List of objects attached to the post, in the following format: "<owner_id>_<media_id>,<owner_id>_<media_id>", '' — Type of media attachment: 'photo' — photo, 'video' — video, 'audio' — audio, 'doc' — document, 'page' — wiki-page, 'note' — note, 'poll' — poll, 'album' — photo album, '<owner_id>' — ID of the media application owner. '<media_id>' — Media application ID. Example: "photo100172_166443618,photo66748_265827614", May contain a link to an external page to include in the post. Example: "photo66748_265827614,http://habrahabr.ru", "NOTE: If more than one link is being attached, an error will be thrown."
    */
-  attachments?: string[];
+  attachments?: string;
   /**
    * Only for posts in communities with 'from_group' set to '1': '1' — post will be signed with the name of the posting user, '0' — post will not be signed (default)
    */
@@ -835,7 +846,10 @@ export interface WallSearchParams {
    * show extended post info.
    */
   extended?: 0 | 1;
-  fields?: BaseUserGroupFields[];
+  /**
+   * objects.json#/definitions/base_user_group_fields
+   */
+  fields?: string;
 }
 
 // wall.search_response

--- a/src/methods/widgets.ts
+++ b/src/methods/widgets.ts
@@ -2,7 +2,6 @@
  * This is auto-generated file, don't modify this file manually
  */
 
-import { UsersFields } from '../objects/users/UsersFields';
 import { WidgetsWidgetComment } from '../objects/widgets/WidgetsWidgetComment';
 import { WidgetsWidgetPage } from '../objects/widgets/WidgetsWidgetPage';
 
@@ -17,7 +16,10 @@ export interface WidgetsGetCommentsParams {
   url?: string;
   page_id?: string;
   order?: string;
-  fields?: UsersFields[];
+  /**
+   * objects.json#/definitions/users_fields
+   */
+  fields?: string;
   offset?: number;
   count?: number;
 }

--- a/src/objects/ads/AdsStatsFormat.ts
+++ b/src/objects/ads/AdsStatsFormat.ts
@@ -29,7 +29,7 @@ export interface AdsStatsFormat {
    */
   overall?: number;
   /**
-   * Reach 
+   * Reach
    */
   reach?: number;
   /**

--- a/src/objects/notes/NotesNoteComment.ts
+++ b/src/objects/notes/NotesNoteComment.ts
@@ -25,7 +25,7 @@ export interface NotesNoteComment {
    */
   oid: number;
   /**
-   * ID of replied comment 
+   * ID of replied comment
    */
   reply_to?: number;
   /**

--- a/src/objects/utils/UtilsStatsSexAge.ts
+++ b/src/objects/utils/UtilsStatsSexAge.ts
@@ -9,11 +9,11 @@ export interface UtilsStatsSexAge {
    */
   age_range?: string;
   /**
-   *  Views by female users
+   * Views by female users
    */
   female?: number;
   /**
-   *  Views by male users
+   * Views by male users
    */
   male?: number;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@vkontakte/api-schema-typescript-generator@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@vkontakte/api-schema-typescript-generator/-/api-schema-typescript-generator-0.4.0.tgz#8c13949090b3e4e1cbdf19573c42f2d03d1405e1"
-  integrity sha512-ENxStsDthVWxYBEDfJ4+4tyYX10Y+4kCcX0UMqZQ76ylHV60hss3kGoPouZbJ0TiCSbq2nryBMtE2cGXgFrxfQ==
+"@vkontakte/api-schema-typescript-generator@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@vkontakte/api-schema-typescript-generator/-/api-schema-typescript-generator-0.5.0.tgz#27920964f59e8418ff2556da563a91ed7978b004"
+  integrity sha512-fsoMJZB2eQ+yfXvTO1oPmC3kw74IL6IWAzbrj6ALsA8cnG3rInOEv7g4SKd8tWr9guaaeGCJ9uTyoCTngZBfOA==
   dependencies:
     arg "^4.1.3"
     chalk "4.1.0"


### PR DESCRIPTION
Now methods parameters with `array` type have string type. The reason is, VK API accepts only a comma-separated string for `array` parameters. This may change in the future when VK API starts accepting a json body.

Before:
```ts
interface SomeMethodParams {
  user_ids: number[];
  filters: string[];
  fields: UsersFields[];
}
```

After:
```ts
interface SomeMethodParams {
  user_ids: string;
  filters: string;
  fields: string;
}
```